### PR TITLE
Shift input improvement

### DIFF
--- a/app/controllers/patterns_controller.rb
+++ b/app/controllers/patterns_controller.rb
@@ -31,6 +31,6 @@ class PatternsController < ApplicationController
   private
 
   def pattern_params
-    params.require(:pattern).permit(:schedule_id, :shift_start, :shift_length, :break_length, :primary_role)
+    params.require(:pattern).permit(:schedule_id, :shift_start, :shift_end, :break_length, :primary_role)
   end
 end

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -48,6 +48,6 @@ class ShiftsController < ApplicationController
   private
 
   def shift_params
-    params.require(:shift).permit(:date, :staff_req, :shift_start, :shift_length, :break_length, :cleaning)
+    params.require(:shift).permit(:date, :staff_req, :shift_start, :shift_end, :break_length, :cleaning)
   end
 end

--- a/app/models/pattern.rb
+++ b/app/models/pattern.rb
@@ -1,5 +1,5 @@
 class Pattern < ApplicationRecord
   has_many :shifts, dependent: :destroy
   belongs_to :user
-  validates_presence_of :user_id
+  validates_presence_of :user_id, :shift_start, :shift_end, :break_length
 end

--- a/app/views/assignments/_edit_assignment.html.erb
+++ b/app/views/assignments/_edit_assignment.html.erb
@@ -16,7 +16,7 @@
       <div class="mx-auto">
       <h1 class= "block text-blue-dark text-xl text-center font-bold pb-2">Change Assignment</h1>
       <%= form.label :shift, class: "sqedule-label" %>
-      <%= form.select :shift, @shifts.collect {|s| ["#{s.pattern.shift_start.strftime("%H:%M")}-#{(s.pattern.shift_start + s.pattern.shift_length.hour * 3600).strftime("%H:%M")} #{s.pattern.primary_role}"] }.concat( ["VAC", "OFF", "OD", "NPP"] ) , {include_blank: false}, id: "dropdown", class: "sqedule-dropdown" %>      
+      <%= form.select :shift, @shifts.collect {|s| ["#{s.pattern.shift_start.strftime("%H:%M")}-#{(s.pattern.shift_end).strftime("%H:%M")} #{s.pattern.primary_role}"] }.concat( ["VAC", "OFF", "OD", "NPP"] ) , {include_blank: false}, id: "dropdown", class: "sqedule-dropdown" %>
 
       <%= form.submit value: "Update", class: "btn btn-blue mt-4" %>   
       <%= button_tag 'Cancel', id: 'cancel_modal', class: 'btn btn-white'%>

--- a/app/views/assignments/_new_assignment.html.erb
+++ b/app/views/assignments/_new_assignment.html.erb
@@ -14,7 +14,7 @@
 			<% end %>
 			<h1 class= "block text-blue-dark text-xl text-center font-bold pb-2">Assign Shift</h1>
 			<%= form.label :shift, class: "sqedule-label" %>
-			<%= form.select :shift, @shifts.collect {|s| ["#{s.pattern.shift_start.strftime("%H:%M")}-#{(s.pattern.shift_start + s.pattern.shift_length.hour * 3600).strftime("%H:%M")} #{s.pattern.primary_role}"]  }.concat( ["VAC", "OFF", "OD", "NPP"] ), {include_blank: false}, id: "dropdown", class: "sqedule-dropdown" %>      
+			<%= form.select :shift, @shifts.collect {|s| ["#{s.pattern.shift_start.strftime("%H:%M")}-#{(s.pattern.shift_end).strftime("%H:%M")} #{s.pattern.primary_role}"]  }.concat( ["VAC", "OFF", "OD", "NPP"] ), {include_blank: false}, id: "dropdown", class: "sqedule-dropdown" %>      
 			<%= form.hidden_field :date, value: @date %>
 			<%= form.submit value: "Assign", class: "btn btn-blue mt-4" %>
 			<%= button_tag 'Cancel', id: 'cancel_modal', class: 'btn btn-white'%>

--- a/app/views/patterns/_new.html.erb
+++ b/app/views/patterns/_new.html.erb
@@ -2,13 +2,13 @@
   <div class="sqedule-form-container">  
     <%= form_with(model: @pattern, local: true, class: 'sqedule-form') do |form| %>
       <%= form.label :shift_start, value: "Shift start (hh:mm)", class: "sqedule-label" %>
-      <%= form.time_field :shift_start, class: "sqedule-input", id: "shift-start"%>
+      <%= form.time_field :shift_start, value: "00:00", class: "sqedule-input", id: "shift-start"%>
       
       <%= form.label :shift_end, value: "Shift end (hh:mm)", class: "sqedule-label" %>
-      <%= form.time_field :shift_end, class: "sqedule-input", id: "shift-end" %>
+      <%= form.time_field :shift_end, value: "00:00", class: "sqedule-input", id: "shift-end" %>
       
       <%= form.label :break_length, value: "Break length (hh:mm)", class: "sqedule-label" %>
-      <%= form.time_field :break_length, class: "sqedule-input", id: "break-length" %>
+      <%= form.time_field :break_length, value: "00:00", class: "sqedule-input", id: "break-length" %>
       
       <%= form.select :primary_role, ["Cleaning", "Selling", "Teaching"], {include_blank: 'Primary Role'}, class: "block appearance-none mt-4 bg-white border border-grey-light hover:border-grey px-4 py-2 pr-8 rounded shadow leading-tight focus:outline-none focus:shadow-outline", id: "primary-role" %>
       

--- a/app/views/patterns/_new.html.erb
+++ b/app/views/patterns/_new.html.erb
@@ -1,13 +1,17 @@
 <%= content_for :modal_content do %>  
   <div class="sqedule-form-container">  
     <%= form_with(model: @pattern, local: true, class: 'sqedule-form') do |form| %>
-      <%= form.label :shift_start, class: "sqedule-label" %>
+      <%= form.label :shift_start, value: "Shift start (hh:mm)", class: "sqedule-label" %>
       <%= form.time_field :shift_start, class: "sqedule-input", id: "shift-start"%>
-      <%= form.label :shift_length, value: "Shift length (h)", class: "sqedule-label" %>
-      <%= form.number_field :shift_length, class: "sqedule-input", id: "shift-length" %>
+      
+      <%= form.label :shift_length, value: "Shift end (hh:mm)", class: "sqedule-label" %>
+      <%= form.time_field :shift_length, class: "sqedule-input", id: "shift-length" %>
+      
       <%= form.label :break_length, value: "Break length (h)", class: "sqedule-label" %>
       <%= form.number_field :break_length, class: "sqedule-input", id: "break-length" %>
+      
       <%= form.select :primary_role, ["Cleaning", "Selling", "Teaching"], {include_blank: 'Primary Role'}, class: "block appearance-none mt-4 bg-white border border-grey-light hover:border-grey px-4 py-2 pr-8 rounded shadow leading-tight focus:outline-none focus:shadow-outline", id: "primary-role" %>
+      
       <%= form.submit value: "Create pattern", class: "btn btn-blue mt-4" %>
       <%= button_tag 'Cancel', id: 'cancel_modal', class: 'btn btn-white'%>
     <% end %>

--- a/app/views/patterns/_new.html.erb
+++ b/app/views/patterns/_new.html.erb
@@ -4,8 +4,8 @@
       <%= form.label :shift_start, value: "Shift start (hh:mm)", class: "sqedule-label" %>
       <%= form.time_field :shift_start, class: "sqedule-input", id: "shift-start"%>
       
-      <%= form.label :shift_length, value: "Shift end (hh:mm)", class: "sqedule-label" %>
-      <%= form.time_field :shift_length, class: "sqedule-input", id: "shift-length" %>
+      <%= form.label :shift_end, value: "Shift end (hh:mm)", class: "sqedule-label" %>
+      <%= form.time_field :shift_end, class: "sqedule-input", id: "shift-end" %>
       
       <%= form.label :break_length, value: "Break length (h)", class: "sqedule-label" %>
       <%= form.number_field :break_length, class: "sqedule-input", id: "break-length" %>

--- a/app/views/patterns/_new.html.erb
+++ b/app/views/patterns/_new.html.erb
@@ -7,8 +7,8 @@
       <%= form.label :shift_end, value: "Shift end (hh:mm)", class: "sqedule-label" %>
       <%= form.time_field :shift_end, class: "sqedule-input", id: "shift-end" %>
       
-      <%= form.label :break_length, value: "Break length (h)", class: "sqedule-label" %>
-      <%= form.number_field :break_length, class: "sqedule-input", id: "break-length" %>
+      <%= form.label :break_length, value: "Break length (hh:mm)", class: "sqedule-label" %>
+      <%= form.time_field :break_length, class: "sqedule-input", id: "break-length" %>
       
       <%= form.select :primary_role, ["Cleaning", "Selling", "Teaching"], {include_blank: 'Primary Role'}, class: "block appearance-none mt-4 bg-white border border-grey-light hover:border-grey px-4 py-2 pr-8 rounded shadow leading-tight focus:outline-none focus:shadow-outline", id: "primary-role" %>
       

--- a/app/views/schedules/_new_pattern.html.erb
+++ b/app/views/schedules/_new_pattern.html.erb
@@ -5,8 +5,8 @@
     <%= form.time_field :shift_start, class: "input-field"%>
   </div>
   <div class="field">
-    <%= form.label :shift_length, value: "Shift length (h)" %>
-    <%= form.number_field :shift_length, class: "input-field" %>
+    <%= form.label :shift_end, value: "Shift end (hh:mm)" %>
+    <%= form.number_field :shift_end, class: "input-field" %>
   </div>
   <div class="field">
     <%= form.label :break_length, value: "Break length (h)" %>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -33,7 +33,7 @@
     <div class="tile-section">
       <% @patterns.each do |pattern|%>
         <div class="tile sqedule-border">
-          <p><%= "#{pattern.shift_start.strftime("%H:%M")}-#{(pattern.shift_end).strftime("%H:%M")}" unless pattern.shift_start.nil? || pattern.shift_end.nil? %></p>
+          <p><%= "#{pattern.shift_start.strftime("%H:%M")}-#{(pattern.shift_end).strftime("%H:%M")} (#{(pattern.break_length).strftime("%H:%M")})" unless pattern.shift_start.nil? || pattern.shift_end.nil? || pattern.break_length.nil? %></p>
           <p><%= pattern.primary_role %></p>
           <p><%= link_to "Delete shift", pattern_path(pattern),  method: :delete, class: "no-underline text-red" %>
         </div>      

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -33,7 +33,7 @@
     <div class="tile-section">
       <% @patterns.each do |pattern|%>
         <div class="tile sqedule-border">
-          <p><%= "#{pattern.shift_start.strftime("%H:%M")}-#{(pattern.shift_start + pattern.shift_length.hour * 3600).strftime("%H:%M")}" unless pattern.shift_start.nil? || pattern.shift_length.nil? %></p>
+          <p><%= "#{pattern.shift_start.strftime("%H:%M")}-#{(pattern.shift_end).strftime("%H:%M")}" unless pattern.shift_start.nil? || pattern.shift_end.nil? %></p>
           <p><%= pattern.primary_role %></p>
           <p><%= link_to "Delete shift", pattern_path(pattern),  method: :delete, class: "no-underline text-red" %>
         </div>      

--- a/db/migrate/20181114130243_change_shift_length_name.rb
+++ b/db/migrate/20181114130243_change_shift_length_name.rb
@@ -1,0 +1,5 @@
+class ChangeShiftLengthName < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :patterns, :shift_length, :shift_end
+  end
+end

--- a/db/migrate/20181114143555_remove_lockedshiftid_and_off_from_assignments.rb
+++ b/db/migrate/20181114143555_remove_lockedshiftid_and_off_from_assignments.rb
@@ -1,0 +1,6 @@
+class RemoveLockedshiftidAndOffFromAssignments < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :assignments, :locked_shift_id
+    remove_column :assignments, :off
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_11_191551) do
+ActiveRecord::Schema.define(version: 2018_11_14_130243) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 2018_11_11_191551) do
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.time "break_length"
-    t.time "shift_length"
+    t.time "shift_end"
     t.string "primary_role"
     t.index ["user_id"], name: "index_patterns_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_14_130243) do
+ActiveRecord::Schema.define(version: 2018_11_14_143555) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "assignments", force: :cascade do |t|
     t.bigint "staff_id"
-    t.boolean "locked_shift_id"
-    t.boolean "off"
     t.string "shift"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/features/shift_pattern.feature
+++ b/features/shift_pattern.feature
@@ -20,7 +20,7 @@ Feature: Shift Pattern
     And I click on "add-pattern"
     And I fill in "shift-start" with formatted time
     And I fill in "shift-end" with formatted time
-    And I fill in "break-length" with "1"
+    And I fill in "break-length" with formatted time
     And I select "Selling" from "primary-role"
     And I click on "Create pattern"
     Then I should see "New shift pattern was successfully created"

--- a/features/shift_pattern.feature
+++ b/features/shift_pattern.feature
@@ -19,7 +19,7 @@ Feature: Shift Pattern
     Given I visit the first planning period
     And I click on "add-pattern"
     And I fill in "shift-start" with formatted time
-    And I fill in "shift-length" with "8"
+    And I fill in "shift-end" with formatted time
     And I fill in "break-length" with "1"
     And I select "Selling" from "primary-role"
     And I click on "Create pattern"

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -86,7 +86,7 @@ Given("I click {string}") do |link|
     click_on link
 end
 
-Given("I visit the first planning period") do   
+Given("I visit the first planning period") do
     visit schedule_path(Schedule.last)
   end
   

--- a/spec/factories/assignments.rb
+++ b/spec/factories/assignments.rb
@@ -1,7 +1,5 @@
 FactoryBot.define do
   factory :assignment do    
-    locked_shift_id { false }
-    off { false }
     shift { "MyString" }
     staff
   end

--- a/spec/factories/patterns.rb
+++ b/spec/factories/patterns.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :pattern do
     shift_start { "2018-11-06 14:59:27" }
     shift_end { "2018-11-06 16:59:27" }
-    break_length { 1 }
+    break_length { "2018-11-06 00:15:00" }
     primary_role { "myString" }
     user
   end

--- a/spec/factories/patterns.rb
+++ b/spec/factories/patterns.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :pattern do
     shift_start { "2018-11-06 14:59:27" }
-    shift_length { 1 }
+    shift_end { "2018-11-06 16:59:27" }
     break_length { 1 }
     primary_role { "myString" }
     user

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe Assignment, type: :model do
   describe 'DB table' do
     it { is_expected.to have_db_column :id }
     it { is_expected.to have_db_column :date }
-    it { is_expected.to have_db_column :off }
-    it { is_expected.to have_db_column :locked_shift_id }
     it { is_expected.to have_db_column :created_at }
     it { is_expected.to have_db_column :updated_at }
     it { is_expected.to have_db_column :staff_id }

--- a/spec/models/pattern_spec.rb
+++ b/spec/models/pattern_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Pattern, type: :model do
   describe 'DB table' do
     it { is_expected.to have_db_column :id }
     it { is_expected.to have_db_column :shift_start }
-    it { is_expected.to have_db_column :shift_length }
+    it { is_expected.to have_db_column :shift_end }
     it { is_expected.to have_db_column :break_length }
     it { is_expected.to have_db_column :created_at }
     it { is_expected.to have_db_column :updated_at }
@@ -13,7 +13,7 @@ RSpec.describe Pattern, type: :model do
   end
 
   describe 'Validations' do
-    it { is_expected.to validate_presence_of :user_id }    
+    it { is_expected.to validate_presence_of :user_id }
   end
 
   describe 'Factory' do


### PR DESCRIPTION
## PivotalTracker:
https://www.pivotaltracker.com/story/show/161953553

## Included:
* Change shift_length field to shift_end, adds migration
* Change format of break_length to time field
* Adds break_length to shift description, eg (00:45)
* Validates presence of shift_start, shift_end and break_length

![image](https://user-images.githubusercontent.com/40142435/48490114-f879d200-e824-11e8-90da-b87a06d969f5.png)

![image](https://user-images.githubusercontent.com/40142435/48490153-10e9ec80-e825-11e8-9b35-957497f21bba.png)

![image](https://user-images.githubusercontent.com/40142435/48490206-3545c900-e825-11e8-8291-240268161642.png)
